### PR TITLE
bump dtype version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.1",
   "main": "index.js",
   "dependencies": {
-    "dtype": "^1.0.0"
+    "dtype": "^2.0.0"
   },
   "devDependencies": {
     "tape": "^2.12.3",


### PR DESCRIPTION
ok.. this again :smile: 

It should be noted that `dtype@2.0.0` no longer includes Buffer... So this patch basically makes it work like it did before in `0.1.0`.
